### PR TITLE
add Transmit DockSend command to ST2 Command Palette

### DIFF
--- a/TransmitDocksend.sublime-commands
+++ b/TransmitDocksend.sublime-commands
@@ -1,0 +1,3 @@
+[
+	{ "caption": "Transmit DockSend", "command": "transmit_docksend"}
+]

--- a/readme.creole
+++ b/readme.creole
@@ -2,7 +2,7 @@
 
 *supports OSX only*
 
-A Sublime Text 2 (http://www.sublimetext.com/2) plugin that provides a key-binding to docksend the current open file through Transmit (http://www.panic.com/transmit/)
+A Sublime Text 2 (http://www.sublimetext.com/2) plugin that provides a command and key binding to docksend the currently open file through Transmit (http://www.panic.com/transmit/)
 
 == Installation
 


### PR DESCRIPTION
Although the keyboard shortcut (⌘U) is a speedy way to access DockSend, I like to discover (and remind myself of) shortcuts like these by finding commands in ST2’s Command Palette. This commit adds the Transmit DockSend command to the Command Palette.
