### PR TITLE
readme tweak changes cmd+u to ⌘U

### DIFF
--- a/readme.creole
+++ b/readme.creole
@@ -14,7 +14,7 @@ git clone git://github.com/jeffturcotte/sublime_transmit_docksend.git ~/Library/
 
 == Usage
 
-Press cmd+u to Docksend the currently open file.
+Press ⌘U to Docksend the currently open file.
 
 == License
 


### PR DESCRIPTION
This is the standard notation used system-wide on OS X to indicate keyboard shortcuts like these.
