### PR TITLE
Send to Active Connection, Command Pallet, Menu Entry and changed Key Binding

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,4 @@
 [
-	{ "keys": ["ctrl+u"], "command": "transmit_docksend" }
+	{ "keys": ["ctrl+u"], "command": "transmit_docksend" },
+	{ "keys": ["ctrl+shift+u"], "command": "transmit_docksend", "args":{"connection":"active"} }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,3 @@
 [
-	{ "keys": ["super+u"], "command": "transmit_docksend" }
+	{ "keys": ["ctrl+u"], "command": "transmit_docksend" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,13 +12,21 @@
                 "children":
                 [
                     {
-                        "caption": "Transmit Docksend",
+                        "caption": "Transmit DockSend",
                         "children":
                         [
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Transmit Docksend/Default.sublime-keymap",
+                                    "file": "${packages}/Transmit DockSend/readme.md"
+                                },
+                                "caption": "README"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/Transmit DockSend/Default.sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – Default"

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,41 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Transmit Docksend",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/Transmit Docksend/Default.sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/TransmitDocksend.py
+++ b/TransmitDocksend.py
@@ -3,16 +3,29 @@ import sublime_plugin
 import subprocess
 
 class TransmitDocksendCommand(sublime_plugin.TextCommand):
-	def run(self, edit):
-		script = """
-		on run
-			ignoring application responses
-				tell application "Transmit"
-					open POSIX file "%s"
+	def run(self, edit, connection=False):
+		if connection == 'active':
+			script = """
+			on run
+			tell application "Transmit"
+				tell current tab of front document
+					tell remote browser
+						upload item at path "%s"
+					end tell
 				end tell
-			end ignoring
-		end run
-		"""
+			end tell
+			end run
+			"""
+		else:
+			script = """
+			on run
+				ignoring application responses
+					tell application "Transmit"
+						open POSIX file "%s"
+					end tell
+				end ignoring
+			end run
+			"""
 
 		proc = subprocess.Popen(
 			["osascript", "-e", script % self.view.file_name()], 

--- a/TransmitDocksend.sublime-commands
+++ b/TransmitDocksend.sublime-commands
@@ -1,0 +1,3 @@
+[
+    { "caption": "Transmit Docksend", "command": "transmit_docksend" }
+]

--- a/TransmitDocksend.sublime-commands
+++ b/TransmitDocksend.sublime-commands
@@ -1,3 +1,4 @@
 [
-    { "caption": "Transmit Docksend", "command": "transmit_docksend" }
+    { "caption": "Transmit DockSend", "command": "transmit_docksend" },
+    { "caption": "Transmit Send with active Connection", "command": "transmit_docksend", "args":{"connection":"active"} }
 ]

--- a/readme.creole
+++ b/readme.creole
@@ -9,12 +9,12 @@ A Sublime Text 2 (http://www.sublimetext.com/2) plugin that provides a key-bindi
 Clone this repository into a TransmitDocksend folder in the ST2 Packages directory.
 
 {{{
-git clone git://github.com/jeffturcotte/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/TransmitDocksend
+git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend
 }}}
 
 == Usage
 
-Press cmd+u to Docksend the currently open file.
+Press ctrl+u to Docksend the currently open file.
 
 == License
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A [Sublime Text 2](http://www.sublimetext.com/2) plugin that adds the option to 
 
 Clone this repository into a "Transmit Docksend" folder in the ST2 Packages directory.
 
-  git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend
+`git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend`
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,24 @@
-= Sublime Transmit Docksend
+#Sublime Transmit DockSend
 
-*supports OSX only*
+*supports OS X only*
 
-A Sublime Text 2 (http://www.sublimetext.com/2) plugin that provides a key-binding to docksend the current open file through Transmit (http://www.panic.com/transmit/)
+A [Sublime Text 2](http://www.sublimetext.com/2) plugin that adds the option to upload the current open file with [Transmit 4](http://www.panic.com/transmit/).
 
-== Installation
+## Installation
 
-Clone this repository into a TransmitDocksend folder in the ST2 Packages directory.
+Clone this repository into a "Transmit Docksend" folder in the ST2 Packages directory.
 
-{{{
-git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend
-}}}
+  git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend
 
-== Usage
+## Usage
 
-Press ctrl+u to Docksend the currently open file.
+### DockSend
+Use `ctrl+u` or `Transmit DockSend` (Command Pallete) to DockSend the current open file.
 
-== License
+### Send with Active Connection
+Use `ctrl+shift+u` or `Transmit Send with Active Connection` (Command Pallete) to upload the current open file with the active Transmit Connection.
+
+## License
 
   Copyright (c) 2011 Jeff Turcotte <jeff.turcotte@gmail.com>
 

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A [Sublime Text 2](http://www.sublimetext.com/2) plugin that adds the option to 
 
 Clone this repository into a "Transmit Docksend" folder in the ST2 Packages directory.
 
-`git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend`
+	git clone git://github.com/mfallend/sublime_transmit_docksend.git ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/Transmit\ Docksend
 
 ## Usage
 


### PR DESCRIPTION
- Added "Send to Active Connection"
- Changed Key Binding to ctrl+u (super+u is a default key binding)
- Added Key Binding for "Send to Active Connection" (ctrl+shift+u)
- Added Comman Pallete Entries
- Added Menu Entries
- Updated README
