### PR TITLE
Fixed broken menu items in ST3

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -18,7 +18,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Transmit DockSend/readme.md"
+                                    "file": "${packages}/Transmit Docksend/readme.md"
                                 },
                                 "caption": "README"
                             },
@@ -26,7 +26,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Transmit DockSend/Default.sublime-keymap",
+                                    "file": "${packages}/Transmit Docksend/Default.sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – Default"


### PR DESCRIPTION
The readme file and default key bindings menu items are broken in ST3 due to a case sensitivity issue.

The packages.json file specifies that the name of the package is 'Transmit Docksend'. Package control uses this version of the package name when installing the package file to 'Installed Packages'.

Meanwhile, the paths in Main.sublime-menu use 'Transmit DockSend'. This doesn't cause any problems in ST2, but in ST3, it can't find the files anymore.

When I changed the case in the package name to be consistent, it started working.

I'm not sure if it's better to change it in the packages.json file or in the menu file itself, but the latter seemed like the path of least resistance.
